### PR TITLE
Add missing package (opencv-python-headless) to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-
 streamlit
 streamlit-image-comparison
+opencv-python-headless


### PR DESCRIPTION
This PR adds opencv-python-headless to requirements.txt to fix the ModuleNotFoundError.